### PR TITLE
+ NSMutableAttributedString.setFontFamily

### DIFF
--- a/Sources/ACExtensions/Swift Standard Library /NSMutableAttributedString + Modify.swift
+++ b/Sources/ACExtensions/Swift Standard Library /NSMutableAttributedString + Modify.swift
@@ -1,0 +1,44 @@
+//
+//  NSMutableAttributedString + Modify.swift
+//  
+//
+//  Created by Анатолий Руденко on 05.03.2022.
+//
+
+import UIKit
+
+extension NSMutableAttributedString {
+    
+    func setFontFamily(font: UIFont, keepOriginalSizes: Bool = true, color: UIColor? = nil) {
+        beginEditing()
+        self.enumerateAttribute(
+            .font,
+            in: NSRange(location: 0, length: self.length)
+        ) { (value, range, _) in
+            if let f = value as? UIFont,
+              let newFontDescriptor = f.fontDescriptor
+                .withFamily(font.familyName)
+                .withSymbolicTraits(f.fontDescriptor.symbolicTraits) {
+
+                let newFont = UIFont(
+                    descriptor: newFontDescriptor,
+                    size: keepOriginalSizes ? f.pointSize : font.pointSize
+                )
+                removeAttribute(.font, range: range)
+                addAttribute(.font, value: newFont, range: range)
+                if let color = color {
+                    removeAttribute(
+                        .foregroundColor,
+                        range: range
+                    )
+                    addAttribute(
+                        .foregroundColor,
+                        value: color,
+                        range: range
+                    )
+                }
+            }
+        }
+        endEditing()
+    }
+}


### PR DESCRIPTION
apply certain font family to NSMutableAttributedString while keeping original fonts' sizes and weights 